### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-#Magento Patches
+# Magento Patches
 
 Welcome to the Magento Patch Exchange. This is an effort to collect all the Magento patches in one spot for both EE and CE. I have been neglectful in properly maintaining this repo but I have made some recent efforts to merge pull requests, answer issues and submit the latest EE patches.
 
-##Reference to patches here
+## Reference to patches here
 https://docs.google.com/spreadsheets/d/1MTbU9Bq130zrrsJwLIB9d8qnGfYZnkm4jBlfNaBF19M/edit#gid=192164130
 
-##What to do?
+## What to do?
 
 If you have a patch that is not in this repo please open a pull request and I will merge the patch. If you see a patch that shouldn’t be there or is just plain wrong, please tell me. I will investigate it and remove it if necessary.
 
-##Issues
+## Issues
 
 Please do not open a support ticket for your Magento site. The best place to get your Magento questions answered is here http://magento.stackexchange.com/ 
 
-##More questions?
+## More questions?
 Please contact me on twitter @brentwpeterson
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
